### PR TITLE
Feature/ Adding new fields to the Feeding Data feature

### DIFF
--- a/controller/chart-create.php
+++ b/controller/chart-create.php
@@ -23,6 +23,14 @@ $app->map('/chart/create', function() use ($app) {
                 $chart->updateMetadata('describe.source-url', $req->post('source-url'));
                 $step = 'visualize';
             }
+            if ($req->post('number-prepend') != null) {
+                $chart->updateMetadata('describe.number-prepend', $req->post('number-prepend'));
+                $step = 'visualize';
+            }
+            if ($req->post('number-append') != null) {
+                $chart->updateMetadata('describe.number-append', $req->post('number-append'));
+                $step = 'visualize';
+            }
             if ($req->post('type') != null) {
                 $chart->setType($req->post('type'));
             }

--- a/dw.js/dw-2.0.js
+++ b/dw.js/dw-2.0.js
@@ -1596,10 +1596,12 @@ dw.chart = function(attributes) {
         onChange: change_callbacks.add,
 
         columnFormatter: function(column) {
-            // pull output config from metadata
-            // return column.formatter(config);
-            var colFormat = chart.get('metadata.data.column-format', {});
-            return column.type(true).formatter(colFormat[column.name()] || {});
+            // take config from `metadata.data.column-format[<column-name>]` otherwhise `metadata.describe`
+            var colFormat = $.extend({},
+                chart.get('metadata.describe'),
+                chart.get('metadata.data.column-format', {})[column.name()] || {}
+            );
+            return column.type(true).formatter(colFormat || {});
         }
 
     };

--- a/dw.js/src/dw.chart.js
+++ b/dw.js/src/dw.chart.js
@@ -201,10 +201,12 @@ dw.chart = function(attributes) {
         onChange: change_callbacks.add,
 
         columnFormatter: function(column) {
-            // pull output config from metadata
-            // return column.formatter(config);
-            var colFormat = chart.get('metadata.data.column-format', {});
-            return column.type(true).formatter(colFormat[column.name()] || {});
+            // take config from `metadata.data.column-format[<column-name>]` otherwhise `metadata.describe`
+            var colFormat = $.extend({},
+                chart.get('metadata.describe'),
+                chart.get('metadata.data.column-format', {})[column.name()] || {}
+            );
+            return column.type(true).formatter(colFormat || {});
         }
 
     };

--- a/www/static/js/dw-2.0.js
+++ b/www/static/js/dw-2.0.js
@@ -1596,10 +1596,12 @@ dw.chart = function(attributes) {
         onChange: change_callbacks.add,
 
         columnFormatter: function(column) {
-            // pull output config from metadata
-            // return column.formatter(config);
-            var colFormat = chart.get('metadata.data.column-format', {});
-            return column.type(true).formatter(colFormat[column.name()] || {});
+            // take config from `metadata.data.column-format[<column-name>]` otherwhise `metadata.describe`
+            var colFormat = $.extend({},
+                chart.get('metadata.describe'),
+                chart.get('metadata.data.column-format', {})[column.name()] || {}
+            );
+            return column.type(true).formatter(colFormat || {});
         }
 
     };


### PR DESCRIPTION
This feature branch adds :

* `number-append` and `number-prepend` fields to the `/chart/create` action
* a new fallback source for the `columnFormatter()` function. If parameters are not found in `metadata.data.column-format[<column-name>]` we take them from `metadata.describe`