### PR TITLE
Improve unit-tests for API

### DIFF
--- a/lib/api/users.php
+++ b/lib/api/users.php
@@ -257,7 +257,7 @@ $app->delete('/users/:id', function($user_id) use ($app) {
         $pwd = $payload->pwd;
     }
     if ($curUser->isLoggedIn()) {
-        if ($user_id == 'current' || $curUser->getId() === $user_id) {
+        if ($user_id == 'current' || $curUser->getId() == $user_id) {
             $user = $curUser;
         } else if ($curUser->isAdmin()) {
             $user = UserQuery::create()->findPK($user_id);


### PR DESCRIPTION
I have cleaned up the API unit-tests such that the tests cleans up after themselves (so, delete the user+chart at the end of the test).

I've also added testing of the publish-functionality.

During the test, I found that it was impossible to delete a user, because the API will always receive the user-id as an string, but it is stored as an integer, so you would end up having `1 === '1'`, which failed.
