### PR TITLE
Fixing column chart axis label rounding errors

### DIFF
--- a/plugins/visualization-column-charts/static/column-chart.js
+++ b/plugins/visualization-column-charts/static/column-chart.js
@@ -386,12 +386,12 @@
                 if (theme.columnChart.cutGridLines) ly += 10;
                 var key = String(val);
                 // show or update label
+
+                //overriding the columnFormatter implementation of grid labels
+                var txt = me.formatValue(val, t == ticks.length-1, false);
                 if (val !== 0) {
-                    var lbl = tickLabels[key] = tickLabels[key] ||
-                        me.label(x+2, ly, formatter(val, t == ticks.length-1, true),
-                            { align: 'left', cl: 'axis', css: { opacity: 0 } });
-                    lbl.animate({ x: c.lpad+2, y: ly, css: { opacity: 1 } }, theme.duration, theme.easing);
-                }
+                   lbl = me.__tickLabels[val] = me.__tickLabels[val] || me.label(x+2, ly, txt, { align: 'left', cl: 'axis', css: { opacity: 0 } });
+                   lbl.animate({ x: x+2, y: ly, css: { opacity: 1 } }, theme.duration, theme.easing);
                 if (theme.yTicks) {
                     me.path([['M', c.lpad-25, y], ['L', c.lpad-20,y]], 'tick');
                 }
@@ -470,6 +470,15 @@
         unhoverSeries: function() {
             this.hoverSeries();
         },
+
+        formatValue: function() {
+            var me = this;
+            // we're overwriting this function with the actual column formatter
+            // when it is first called (lazy evaluation)
+            me.formatValue = me.chart().columnFormatter(me.axes(true).columns[0]);
+            return me.formatValue.apply(me, arguments);
+        },
+
 
         gridVisible: function() {
             var me = this;

--- a/plugins/visualization-column-charts/static/grouped-column-chart.js
+++ b/plugins/visualization-column-charts/static/grouped-column-chart.js
@@ -262,7 +262,7 @@
             _.each(ticks, function(val, t) {
                 var y = c.h - c.bpad - yscale(val),
                     x = c.lpad, ly = y-10, lbl,
-                    txt = me.formatValue(val, t == ticks.length-1, true);
+                    txt = me.formatValue(val, t == ticks.length-1, false);
                 // c.paper.text(x, y, val).attr(styles.labels).attr({ 'text-anchor': 'end' });
                 if (me.theme().columnChart.cutGridLines) ly += 10;
 


### PR DESCRIPTION
A change we made in the soon-to-be-open sourced (the next few days, it'll be in https://github.com/washingtonpost/datawrapper) datawrapper fork, that addresses rounding errors on column chart axes.

There's some inconsistency between how column chart and grouped-column chart
is structred, looking at the `horzGrid` is just one example (compare how `theme` is defined),
`__gridlabels` vs `tickLabels`, etc.)

The fundamental challenge here was parsing out when `formatValue` in dw.js/src/dw.chart.js was used (which accepts a boolean rounding arg), and when `formatValue` defined in the plug was used (which just overrides the former func and replaces it with `columnFormatter` in `/dw.js/dw-2.0.js`)
