### PR TITLE
Improve SSL detection

### DIFF
--- a/lib/utils/chart_content.php
+++ b/lib/utils/chart_content.php
@@ -3,7 +3,7 @@
 function get_chart_content($chart, $user, $published = false, $debug = false) {
     $theme_css = array();
     $theme_js = array();
-    $protocol = !empty($_SERVER['HTTPS']) ? "https" : "http";
+    $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https" : "http";
 
     $next_theme_id = $chart->getTheme();
 


### PR DESCRIPTION
Some servers return the string "off" when SSL is not enabled; this check fixes the app to load assets correctly in that situation.
