### PR TITLE
Removed reference to subfolders which do not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,5 @@ messages:
 www/static/css/datawrapper.css: assets/styles/datawrapper/* assets/styles/datawrapper/**/*
 	node_modules/.bin/lessc assets/styles/datawrapper/main.less > $@
 
-www/static/css/chart.base.css: assets/styles/chart.base/* assets/styles/chart.base/**/*
+www/static/css/chart.base.css: assets/styles/chart.base/*
 	node_modules/.bin/lessc assets/styles/chart.base/main.less > $@


### PR DESCRIPTION
Hi,

I ran into the same issue as datawrapper/datawrapper#135 and found that by removing the Makefile reference to **/* for chart.base I could get `make` to build. I ran into this issue on OS X 10.10 and Ubuntu 14.04, but I'm unsure if there are other versions of make this isn't a problem for.

Hope this helps.