### PR TITLE
Convert _ to - when building culture URL

### DIFF
--- a/dw.js/src/dw.chart.js
+++ b/dw.js/src/dw.chart.js
@@ -117,7 +117,7 @@ dw.chart = function(attributes) {
                     if (typeof callback == "function") callback();
                 } else {
                     $.getScript("/static/vendor/globalize/cultures/globalize.culture." +
-                      locale + ".js", function () {
+                      locale.replace('_', '-') + ".js", function () {
        
                         chart.locale(locale);
                         if (typeof callback == "function") callback();


### PR DESCRIPTION
When building URLs to the `globalize,culture.LOCALE.js` files we need to convert "_" to "-" to avoid a 404 error (similar to the changes in 4a0c3ef and 1ace1cb).