### PR TITLE
Avoid infinite loop when loading globalize.culture.*.js

### DIFF
--- a/dw.js/src/dw.chart.js
+++ b/dw.js/src/dw.chart.js
@@ -111,13 +111,13 @@ dw.chart = function(attributes) {
 
         locale: function(_locale, callback) {
             if (arguments.length) {
-                locale = _locale;
+                locale = _locale.replace('_', '-');
                 if (Globalize.cultures.hasOwnProperty(locale)) {
                     Globalize.culture(locale);
                     if (typeof callback == "function") callback();
                 } else {
                     $.getScript("/static/vendor/globalize/cultures/globalize.culture." +
-                      locale.replace('_', '-') + ".js", function () {
+                      locale + ".js", function () {
        
                         chart.locale(locale);
                         if (typeof callback == "function") callback();


### PR DESCRIPTION
The fix in my previous pull request (#167) was too specific and resulted in an infinite loop when trying to load the `globalise.culture.*.js` files:

![screenshot 2015-08-21 at 14 49 10](https://cloud.githubusercontent.com/assets/53680/9461790/42b92780-4b11-11e5-8e28-4f38996722d5.png)

This patch tries to remedy the situation.