### PR TITLE
Removed unnecessary substr() call

### DIFF
--- a/lib/session/DatawrapperSession.php
+++ b/lib/session/DatawrapperSession.php
@@ -147,7 +147,7 @@ class DatawrapperSession {
      */
     public static function getLanguage() {
         // use language set via ?lang=, if set
-        if (!empty($_GET['lang'])) return str_replace('-', '_', substr($_GET['lang']));
+        if (!empty($_GET['lang'])) return str_replace('-', '_', $_GET['lang']);
 
         // otherwise use user preference, or browser language
         if (self::getUser()->isLoggedIn()) {


### PR DESCRIPTION
It doesn't look like this `substr()` call is necessary. 