### PR TITLE
Fix nonexistent links in invitation email

### DIFF
--- a/templates/core.twig
+++ b/templates/core.twig
@@ -71,7 +71,7 @@
   <body class="dw {{ pageClass }} {{ language }}" data-locale="{{ locale }}">
 
     {% if maintenance == true %}
-        <div style="height:100%; width:100%; overflow:hidden; z-index:1000; position: absolute; top:0;left:0; background:#fff; text-align:center;">
+        <div style="height:100%; width:100%; overflow:hidden; z-index:10000; position: absolute; top:0;left:0; background:#fff; text-align:center;">
           <div style="width:500px; display:inline-block; margin-top:100px;">
               <h1>Datawrapper is undergoing some maintenance.</h1>
               <h2>We'll be right back. (Your charts are unaffected by this, they always stay online.)</h2>


### PR DESCRIPTION
The invitation hooks had `invite_link` instead of `invitation_link` which was preventing the invitation emails from containing a clickable URL.
