### PR TITLE
Use relative URLs when redirecting to the current published chart ver…

### DIFF
--- a/lib/core/build/classes/datawrapper/Chart.php
+++ b/lib/core/build/classes/datawrapper/Chart.php
@@ -335,11 +335,20 @@ class Chart extends BaseChart {
      */
     public function redirectPreviousVersions() {
         $current_target = $this->getCDNPath();
-        $redirect_html = '<html><head><meta http-equiv="REFRESH" content="0; url=/'.$current_target.'"></head></html>';
-        $redirect_file = chart_publish_directory() . 'static/' . $this->getID() . '/redirect.html';
+
+        $redirect_html_ver0 = '<html><head><meta http-equiv="REFRESH" content="0; url=../'. $current_target.'"></head></html>';
+        $redirect_file_ver0 = chart_publish_directory() . 'static/' . $this->getID() . '/redirect.html';
+        file_put_contents($redirect_file_ver0, $redirect_html_ver0);
+
+        # redirect previous versions to a relative URL (../CURRENT_VERSION)
+        $redirect_html = '<html><head><meta http-equiv="REFRESH" content="0; url=../../'. $current_target.'"></head></html>';
+        $redirect_file = chart_publish_directory() . 'static/' . $this->getID() . '/redirect_version.html';
         file_put_contents($redirect_file, $redirect_html);
+
         $files = array();
-        for ($v=0; $v < $this->getPublicVersion(); $v++) {
+        $files[] = array($redirect_file_ver0, $this->getCDNPath(0) . 'index.html', 'text/html');
+
+        for ($v=1; $v < $this->getPublicVersion(); $v++) {
             $files[] = array($redirect_file, $this->getCDNPath($v) . 'index.html', 'text/html');
         }
         DatawrapperHooks::execute(DatawrapperHooks::PUBLISH_FILES, $files);


### PR DESCRIPTION
Sometimes charts are not published to the root dir, so redirecting to /VERSION doesn't makes any sense.
This patch will redirect to a relative directory.