### PR TITLE
Fix database schema initalisation

### DIFF
--- a/lib/core/build/sql/schema.sql
+++ b/lib/core/build/sql/schema.sql
@@ -433,7 +433,7 @@ CREATE TABLE `folder`
     CONSTRAINT `folder_FK_3`
         FOREIGN KEY (`org_id`)
         REFERENCES `organization` (`id`)
-) ENGINE=InnoDB CHARACTER SET='utf8';
+) ENGINE=InnoDB;
 
 -- ---------------------------------------------------------------------
 -- user_data


### PR DESCRIPTION
When installing Datawrapper following the [alternative setup](https://github.com/datawrapper/datawrapper/wiki/Datawrapper-self-hosted-setup-instructions) it's not possible to setup the database schema with

```bash
mysql -u <user> -p datawrapper < lib/core/build/sql/schema.sql
```

By not enforcing UTF8 in the `folder` table the error is gone, so you can initialise the database schema. 

Closes https://github.com/datawrapper/datawrapper/issues/224.