### PR TITLE
Load browser-specific polyfills before rendering charts

### DIFF
--- a/templates/chart.twig
+++ b/templates/chart.twig
@@ -213,14 +213,12 @@
 
     // load polyfills
     (function() {
+        // see https://github.com/datawrapper/polyfills/blob/master/getBrowser.js
         function getBrowser(){var e=!!window.opr&&!!opr.addons||!!window.opera||navigator.userAgent.indexOf(" OPR/")>=0;var r=typeof InstallTrigger!=="undefined";var o=/constructor/i.test(window.HTMLElement)||function(e){return e.toString()==="[object SafariRemoteNotification]"}(!window["safari"]||safari.pushNotification);var i=false||!!document.documentMode;var n=!i&&!!window.StyleMedia;var a=!!window.chrome&&!!window.chrome.loadTimes;var t=(a||e)&&!!window.CSS;var s=a?"chrome":r?"firefox":o?"safari":i?"ie":n?"edge":false;var f=a?getVersion(/chrom(?:e|ium)\/([0-9]+)\./):r?getVersion(/firefox\/([0-9]+\.*[0-9]*)/):o?getVersion(/version\/([0-9+]).[0-9+].[0-9+] safari/):i?getVersion(/msie ([0-9+]).[0-9+].[0-9+]/):n?getVersion(/edge\/([0-9+]).[0-9+].[0-9+]/):false;return{browser:s,version:f};function getVersion(e){var r=navigator.userAgent.toLowerCase().match(e);return r?parseInt(r[1],10):false}}
 
         var avail = {
-            firefox: [30, 51],
-            chrome: [20, 54],
-            ie: [6,11],
-            edge: [12,18],
-            safari: [6,12],
+            firefox: [30, 51], chrome: [20, 54], ie: [6,11],
+            edge: [12,18], safari: [6,12]
         };
 
         var dev = getBrowser();

--- a/templates/chart.twig
+++ b/templates/chart.twig
@@ -216,7 +216,7 @@
         // see https://github.com/datawrapper/polyfills/blob/master/getBrowser.js
         function getBrowser(){var e=!!window.opr&&!!opr.addons||!!window.opera||navigator.userAgent.indexOf(" OPR/")>=0;var r=typeof InstallTrigger!=="undefined";var o=/constructor/i.test(window.HTMLElement)||function(e){return e.toString()==="[object SafariRemoteNotification]"}(!window["safari"]||safari.pushNotification);var i=false||!!document.documentMode;var n=!i&&!!window.StyleMedia;var a=!!window.chrome&&!!window.chrome.loadTimes;var t=(a||e)&&!!window.CSS;var s=a?"chrome":r?"firefox":o?"safari":i?"ie":n?"edge":false;var f=a?getVersion(/chrom(?:e|ium)\/([0-9]+)\./):r?getVersion(/firefox\/([0-9]+\.*[0-9]*)/):o?getVersion(/version\/([0-9+]).[0-9+].[0-9+] safari/):i?getVersion(/msie ([0-9+]).[0-9+].[0-9+]/):n?getVersion(/edge\/([0-9+]).[0-9+].[0-9+]/):false;return{browser:s,version:f};function getVersion(e){var r=navigator.userAgent.toLowerCase().match(e);return r?parseInt(r[1],10):false}}
 
-        var avail = {
+        var availablePolyfills = {
             firefox: [30, 51], chrome: [20, 54], ie: [6,11],
             edge: [12,18], safari: [6,12]
         };
@@ -227,8 +227,9 @@
         script.async = true;
         script.onload = run;
         script.onerror = run;
-        if (dev.browser && avail[dev.browser] && dev.version >= avail[dev.browser][0]) {
-            if (dev.version > avail[dev.browser][1]) {
+        if (dev.browser && availablePolyfills[dev.browser] &&
+            dev.version >= availablePolyfills[dev.browser][0]) {
+            if (dev.version > availablePolyfills[dev.browser][1]) {
                 // no need for polyfill, browser is quite new
                 return run();
             }

--- a/templates/chart.twig
+++ b/templates/chart.twig
@@ -236,7 +236,7 @@
             script.src = 'https://datawrapper.dwcdn.net/lib/polyfills/'+dev.browser+'-'+dev.version+'.js';
         } else {
             // fall back to core js
-            script.src = 'https://cdnjs.cloudflare.com/ajax/libs/core-js/2.6.1/core.min.js';
+            script.src = 'https://datawrapper.dwcdn.net/lib/polyfills/core.min.js';
         }
         document.getElementsByTagName('head')[0].appendChild(script);
     })();

--- a/templates/chart.twig
+++ b/templates/chart.twig
@@ -211,44 +211,76 @@
 
     var visJSON = {{ visualization | json | raw }};
 
+    // load polyfills
+    (function() {
+        function getBrowser(){var e=!!window.opr&&!!opr.addons||!!window.opera||navigator.userAgent.indexOf(" OPR/")>=0;var r=typeof InstallTrigger!=="undefined";var o=/constructor/i.test(window.HTMLElement)||function(e){return e.toString()==="[object SafariRemoteNotification]"}(!window["safari"]||safari.pushNotification);var i=false||!!document.documentMode;var n=!i&&!!window.StyleMedia;var a=!!window.chrome&&!!window.chrome.loadTimes;var t=(a||e)&&!!window.CSS;var s=a?"chrome":r?"firefox":o?"safari":i?"ie":n?"edge":false;var f=a?getVersion(/chrom(?:e|ium)\/([0-9]+)\./):r?getVersion(/firefox\/([0-9]+\.*[0-9]*)/):o?getVersion(/version\/([0-9+]).[0-9+].[0-9+] safari/):i?getVersion(/msie ([0-9+]).[0-9+].[0-9+]/):n?getVersion(/edge\/([0-9+]).[0-9+].[0-9+]/):false;return{browser:s,version:f};function getVersion(e){var r=navigator.userAgent.toLowerCase().match(e);return r?parseInt(r[1],10):false}}
 
-    __dw.init($.extend({
-        chartJSON: {{ chart.toStruct(true) | json | raw }},
-        preview: {{ preview ? 'true' : 'false' }},
-        chartLocale: '{{ chartLocale }}',
-        themeId: '{{ theme.id }}',
-        visId: '{{ visualization.id }}',
-        visJSON: visJSON,
-        metricPrefix: {{ metricPrefix | json | raw }},
-        lang: '{{ lang }}',
-        data: {{ chartData | json | raw }}
-    }, window.__dwParams));
+        var avail = {
+            firefox: [30, 51],
+            chrome: [20, 54],
+            ie: [6,11],
+            edge: [12,18],
+            safari: [6,12],
+        };
 
-    if (/iP(hone|od|ad)/.test(navigator.platform)) {
-        window.onload = __dw.render();
+        var dev = getBrowser();
+        var script = document.createElement("script");
+        script.type = 'text/javascript';
+        script.async = true;
+        script.onload = run;
+        script.onerror = run;
+        if (dev.browser && avail[dev.browser] && dev.version >= avail[dev.browser][0]) {
+            if (dev.version > avail[dev.browser][1]) {
+                // no need for polyfill, browser is quite new
+                return run();
+            }
+            // use cached polyfill.io polyfills
+            script.src = 'https://datawrapper.dwcdn.net/lib/polyfills/'+dev.browser+'-'+dev.version+'.js';
+        } else {
+            // fall back to core js
+            script.src = 'https://cdnjs.cloudflare.com/ajax/libs/core-js/2.6.1/core.min.js';
+        }
+        document.getElementsByTagName('head')[0].appendChild(script);
+    })();
+
+    function run() {
+        __dw.init($.extend({
+            chartJSON: {{ chart.toStruct(true) | json | raw }},
+            preview: {{ preview ? 'true' : 'false' }},
+            chartLocale: '{{ chartLocale }}',
+            themeId: '{{ theme.id }}',
+            visId: '{{ visualization.id }}',
+            visJSON: visJSON,
+            metricPrefix: {{ metricPrefix | json | raw }},
+            lang: '{{ lang }}',
+            data: {{ chartData | json | raw }}
+        }, window.__dwParams));
+
+        if (/iP(hone|od|ad)/.test(navigator.platform)) {
+            window.onload = __dw.render();
+        }
+
+        if (visJSON.height == "fixed") {
+            setInterval(function() {
+                var desiredHeight = $('html').outerHeight(true);
+                window.parent.postMessage({
+                    'datawrapper-height': {
+                        '{{ chart.id }}': desiredHeight
+                    }
+                }, "*");
+
+                window.parent.postMessage({
+                    sentinel: 'amp',
+                    type: 'embed-size',
+                    height: desiredHeight
+                }, '*');
+            }, 1000);
+        }
+
+        {% if theme.getThemeData('template.js') %}
+            {{ theme.getThemeData('template.js') | raw }}
+        {% endif %}
     }
-
-    if (visJSON.height == "fixed") {
-        setInterval(function() {
-            var desiredHeight = $('html').outerHeight(true);
-            window.parent.postMessage({
-                'datawrapper-height': {
-                    '{{ chart.id }}': desiredHeight
-                }
-            }, "*");
-
-            window.parent.postMessage({
-                sentinel: 'amp',
-                type: 'embed-size',
-                height: desiredHeight
-            }, '*');
-        }, 1000);
-    }
-
-    {% if theme.getThemeData('template.js') %}
-        {{ theme.getThemeData('template.js') | raw }}
-    {% endif %}
-
     </script>
 
 </body>


### PR DESCRIPTION
The proposal is the following: before rendering a chart 

1. we detect the **browser** and the **version**
2. don't load any polyfill if we don't need one (i.e. for modern chrome)
3. if we need a polyfill we either serve have a browser-specific polyfill (e.g. [ie-10.js](https://datawrapper.dwcdn.net/lib/polyfills/ie-10.js) ) or fall back to [core-js](https://cdnjs.cloudflare.com/ajax/libs/core-js/2.6.1/core.min.js)

To detect the browser and the version I suggest to use [this function](https://github.com/datawrapper/polyfills/blob/master/getBrowser.js) which isn't based on the user-agent but on feature-detection. 

The browser-specific polyfills are coming from the polyfill.io service, but are cached on our CDN. to generate all the browser-version combinations I used [this little script](https://github.com/datawrapper/polyfills/blob/master/index.js) which is simply generating user agent strings and then downloading the polyfill from polyfill.io.

In chart.twig the chart rendering is now wrapped in a `run()` function which is either delayed until after the polyfill is loaded or immediately executed in case we don't need a polyfill.