### PR TITLE
revert and try-catch old bug

### DIFF
--- a/plugins/visualization-data-table/static/data-table.js
+++ b/plugins/visualization-data-table/static/data-table.js
@@ -179,7 +179,14 @@
                 last_sort = [dataset.indexOf(me.get('sort-by')), me.get('sort-asc') ? 'asc' : 'desc'];
             }
 
-            if (last_sort && last_sort > -1) {table.fnSort([last_sort]); }
+            if (last_sort) {
+                try {
+                    table.fnSort([last_sort]);
+                }
+                catch(err) {
+                    console.error(err);
+                }
+            }
 
             $('thead th').click(function() {
                 var th = $('th[aria-sort]', table),


### PR DESCRIPTION
As per suggestion from Gregor, reverted to what it was before I broke it and used try-catch to ensure that the sorting error doesn't prevent the rest of the code from being executed. 