### PR TITLE
Replace environment variables in config.yaml after parsing

### DIFF
--- a/lib/bootstrap.php
+++ b/lib/bootstrap.php
@@ -11,15 +11,8 @@ require_once ROOT_PATH . 'vendor/autoload.php';
 define('CLI', php_sapi_name() == "cli");
 
 // load YAML parser and config
-$GLOBALS['dw_config'] = $dw_config = Spyc::YAMLLoad(ROOT_PATH . 'config.yaml');
+$GLOBALS['dw_config'] = $dw_config = parse_config(Spyc::YAMLLoad(ROOT_PATH . 'config.yaml'));
 
-// replace environment variables in config.yaml
-// the expected format is $_ENV[...], e.g. $_ENV[DW_DATABASE_USER]
-array_walk_recursive($GLOBALS['dw_config'], function(&$value, $key) {
-    if (preg_match('/\$_ENV\[([^\]]+)\]/', $value, $matches)) {
-        $value = getenv($matches[1]) ?? $matches[1];
-    }
-});
 
 if (isset($dw_config['debug']) && $dw_config['debug'] == true) {
     error_reporting(E_ALL);
@@ -109,8 +102,6 @@ setlocale(LC_TIME, $locale.'.utf8');
 
 $__l10n = new Datawrapper_L10N();
 $__l10n->loadMessages($locale);
-
-parse_config();
 
 if (!defined('NO_SLIM')) {
     // Initialize Slim app..

--- a/lib/bootstrap.php
+++ b/lib/bootstrap.php
@@ -13,6 +13,14 @@ define('CLI', php_sapi_name() == "cli");
 // load YAML parser and config
 $GLOBALS['dw_config'] = $dw_config = Spyc::YAMLLoad(ROOT_PATH . 'config.yaml');
 
+// replace environment variables in config.yaml
+// the expected format is $_ENV[...], e.g. $_ENV[DW_DATABASE_USER]
+array_walk_recursive($GLOBALS['dw_config'], function(&$value, $key) {
+    if (preg_match('/\$_ENV\[([^\]]+)\]/', $value, $matches)) {
+        $value = getenv($matches[1]) ?? $matches[1];
+    }
+});
+
 if (isset($dw_config['debug']) && $dw_config['debug'] == true) {
     error_reporting(E_ALL);
     ini_set('display_errors', 1);
@@ -83,7 +91,7 @@ if (!defined('NO_SESSION')) {
         ob_start();
     } else {
         ob_start("ob_gzhandler");
-    }    
+    }
 }
 
 function debug_log($txt) {

--- a/lib/utils/parse_config.php
+++ b/lib/utils/parse_config.php
@@ -4,8 +4,14 @@
  * parses the config and populates some defaults
  */
 
-function parse_config() {
-    $cfg = $GLOBALS['dw_config'];
+function parse_config($cfg) {
+    // replace environment variables in config.yaml
+    // the expected format is $_ENV[...], e.g. $_ENV[DW_DATABASE_USER]
+    array_walk_recursive($cfg, function(&$value, $key) {
+        if (preg_match('/\$_ENV\[([^\]]+)\]/', $value, $matches)) {
+            $value = getenv($matches[1]);
+        }
+    });
 
     // check that email adresses are set
     if (!isset($cfg['email']))
@@ -23,5 +29,5 @@ function parse_config() {
     if (!isset($cfg['asset_domain']))
         $cfg['asset_domain'] = false;
 
-    $GLOBALS['dw_config'] = $cfg;
+    return $cfg;
 }


### PR DESCRIPTION
I moved the `parse_config()` up, don't think there's any negative side effect. but maybe you see something that I don't?