### PR TITLE
Docker fixes

### DIFF
--- a/lib/core/build/classes/datawrapper/ChartQuery.php
+++ b/lib/core/build/classes/datawrapper/ChartQuery.php
@@ -44,8 +44,6 @@ class ChartQuery extends BaseChartQuery {
         $chart->setType(isset($defaults['vis']) ? $defaults['vis'] : 'bar-chart');
         $chart->setPublicUrl($chart->getLocalUrl());
 
-
-        // todo: use global default theme
         $chart->setTheme(isset($defaults['theme']) ? $defaults['theme'] : 'default');
 
         if ($user->isLoggedIn()) {
@@ -64,17 +62,10 @@ class ChartQuery extends BaseChartQuery {
         }
 
         $defaultMeta = Chart::defaultMetaData();
+        $themeMeta = ThemeQuery::create()->findPk($chart->getTheme())->getThemeData('metadata') ?? [];
+        $meta = array_merge_recursive_simple($defaultMeta, $themeMeta);
+        $chart->setMetadata(json_encode($meta));
 
-        if (isset($def_org_theme_default_width)) {
-            $defaultMeta['publish']['embed-width'] = $def_org_theme_default_width;
-        }
-
-        if (isset($def_org_theme_default_height)) {
-            $defaultMeta['publish']['embed-height'] = $def_org_theme_default_height;
-        }
-
-        $chart->setMetadata(json_encode($defaultMeta));
-        // $chart->setLanguage($user->getLanguage());  // defaults to user language
         $chart->setShowInGallery(isset($defaults['show_in_gallery']) ? $defaults['show_in_gallery'] : false);
         $chart->save();
         return $chart;

--- a/lib/utils/add_header_vars.php
+++ b/lib/utils/add_header_vars.php
@@ -303,25 +303,25 @@ function add_header_vars(&$page, $active = null, $page_css = null) {
         }
     }
 
-    // if ($config['debug']) {
-    try {
-        if (file_exists('../.git')) {
-            // parse git branch
-            $head = file_get_contents('../.git/HEAD');
-            $parts = explode("/", $head);
-            $branch = trim($parts[count($parts)-1]);
-            $output = array();
-            exec('git rev-parse HEAD', $output);
-            $commit = $output[0];
-            $page['COMMIT_SHA'] = substr($commit, 0, 8);
-            if ($config['debug']) {
-                $page['BRANCH'] = ' (<a href="https://github.com/datawrapper/datawrapper/tree/'.$commit.'">'.$branch.'</a>)';
+    if ($config['debug']) {
+        try {
+            if (file_exists('../.git')) {
+                // parse git branch
+                $head = file_get_contents('../.git/HEAD');
+                $parts = explode("/", $head);
+                $branch = trim($parts[count($parts)-1]);
+                $output = array();
+                exec('git rev-parse HEAD', $output);
+                $commit = $output[0];
+                $page['COMMIT_SHA'] = substr($commit, 0, 8);
+                if ($config['debug']) {
+                    $page['BRANCH'] = ' (<a href="https://github.com/datawrapper/datawrapper/tree/'.$commit.'">'.$branch.'</a>)';
+                }
             }
+        } catch (Error $e) {
+            // ignore
+            $page['COMMIT_SHA'] = 'error';
         }
-    } catch (Error $e) {
-        // ignore
-        $page['COMMIT_SHA'] = 'error';
     }
-    // }
 }
 

--- a/lib/utils/parse_config.php
+++ b/lib/utils/parse_config.php
@@ -8,7 +8,7 @@ function parse_config($cfg) {
     // replace environment variables in config.yaml
     // the expected format is $_ENV[...], e.g. $_ENV[DW_DATABASE_USER]
     array_walk_recursive($cfg, function(&$value, $key) {
-        if (preg_match('/\$_ENV\[([^\]]+)\]/', $value, $matches)) {
+        while (preg_match('/\$_ENV\[([^\]]+)\]/', $value, $matches)) {
             $value = str_replace('$_ENV['.$matches[1].']', getenv($matches[1]), $value);
         }
     });

--- a/migrations/001-initial-schema.sql
+++ b/migrations/001-initial-schema.sql
@@ -48,7 +48,7 @@ CREATE TABLE `chart`
     CONSTRAINT `chart_FK_4`
         FOREIGN KEY (`in_folder`)
         REFERENCES `folder` (`folder_id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `chart_public`
@@ -65,7 +65,7 @@ CREATE TABLE `chart_public`
     CONSTRAINT `chart_public_FK_1`
         FOREIGN KEY (`id`)
         REFERENCES `chart` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `user`
@@ -85,7 +85,7 @@ CREATE TABLE `user`
     `oauth_signin` VARCHAR(512),
     `customer_id` VARCHAR(512),
     PRIMARY KEY (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `organization`
@@ -98,7 +98,7 @@ CREATE TABLE `organization`
     `default_theme` VARCHAR(128) DEFAULT '',
     `settings` LONGTEXT,
     PRIMARY KEY (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `user_organization`
@@ -115,7 +115,7 @@ CREATE TABLE `user_organization`
     CONSTRAINT `user_organization_FK_2`
         FOREIGN KEY (`organization_id`)
         REFERENCES `organization` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 
@@ -132,7 +132,7 @@ CREATE TABLE `action`
     CONSTRAINT `action_FK_1`
         FOREIGN KEY (`user_id`)
         REFERENCES `user` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `stats`
@@ -142,7 +142,7 @@ CREATE TABLE `stats`
     `metric` VARCHAR(255) NOT NULL,
     `value` INTEGER NOT NULL,
     PRIMARY KEY (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `session`
@@ -152,7 +152,7 @@ CREATE TABLE `session`
     `last_updated` DATETIME NOT NULL,
     `session_data` LONGTEXT NOT NULL,
     PRIMARY KEY (`session_id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `job`
@@ -175,7 +175,7 @@ CREATE TABLE `job`
     CONSTRAINT `job_FK_2`
         FOREIGN KEY (`chart_id`)
         REFERENCES `chart` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `plugin`
@@ -185,7 +185,7 @@ CREATE TABLE `plugin`
     `enabled` TINYINT(1) DEFAULT 0,
     `is_private` TINYINT(1) DEFAULT 0,
     PRIMARY KEY (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `plugin_organization`
@@ -200,7 +200,7 @@ CREATE TABLE `plugin_organization`
     CONSTRAINT `plugin_organization_FK_2`
         FOREIGN KEY (`organization_id`)
         REFERENCES `organization` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `plugin_data`
@@ -215,7 +215,7 @@ CREATE TABLE `plugin_data`
     CONSTRAINT `plugin_data_FK_1`
         FOREIGN KEY (`plugin_id`)
         REFERENCES `plugin` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `product`
@@ -227,7 +227,7 @@ CREATE TABLE `product`
     `priority` INTEGER DEFAULT 0,
     `data` LONGTEXT,
     PRIMARY KEY (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 CREATE TABLE `product_plugin`
 (
@@ -241,7 +241,7 @@ CREATE TABLE `product_plugin`
     CONSTRAINT `product_plugin_FK_2`
         FOREIGN KEY (`plugin_id`)
         REFERENCES `plugin` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 CREATE TABLE `user_product`
 (
@@ -258,7 +258,7 @@ CREATE TABLE `user_product`
     CONSTRAINT `user_product_FK_2`
         FOREIGN KEY (`product_id`)
         REFERENCES `product` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 CREATE TABLE `organization_product`
 (
@@ -275,7 +275,7 @@ CREATE TABLE `organization_product`
     CONSTRAINT `organization_product_FK_2`
         FOREIGN KEY (`product_id`)
         REFERENCES `product` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 CREATE TABLE `theme`
 (
@@ -287,7 +287,7 @@ CREATE TABLE `theme`
     `less` LONGTEXT,
     `assets` LONGTEXT,
     PRIMARY KEY (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `organization_theme`
@@ -302,7 +302,7 @@ CREATE TABLE `organization_theme`
     CONSTRAINT `organization_theme_FK_2`
         FOREIGN KEY (`theme_id`)
         REFERENCES `theme` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 CREATE TABLE `user_theme`
 (
@@ -316,7 +316,7 @@ CREATE TABLE `user_theme`
     CONSTRAINT `user_theme_FK_2`
         FOREIGN KEY (`theme_id`)
         REFERENCES `theme` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `folder`
@@ -339,7 +339,7 @@ CREATE TABLE `folder`
     CONSTRAINT `folder_FK_3`
         FOREIGN KEY (`org_id`)
         REFERENCES `organization` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 CREATE TABLE `user_data`
 (
@@ -353,7 +353,7 @@ CREATE TABLE `user_data`
     CONSTRAINT `user_data_FK_1`
         FOREIGN KEY (`user_id`)
         REFERENCES `user` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `user_plugin_cache`
@@ -364,7 +364,7 @@ CREATE TABLE `user_plugin_cache`
     CONSTRAINT `user_plugin_cache_FK_1`
         FOREIGN KEY (`user_id`)
         REFERENCES `user` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `auth_token`
@@ -380,7 +380,7 @@ CREATE TABLE `auth_token`
     CONSTRAINT `auth_token_FK_1`
         FOREIGN KEY (`user_id`)
         REFERENCES `user` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 
 CREATE TABLE `login_token`
@@ -394,7 +394,7 @@ CREATE TABLE `login_token`
     CONSTRAINT `login_token_FK_1`
         FOREIGN KEY (`user_id`)
         REFERENCES `user` (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARSET=utf8;
 
 # This restores the fkey checks, after having unset them earlier
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
two fixes in here:

1. in `lib/utils/parse_config.php`: i've replaced the `if` with a `while` to ensure that datawrapper replaces **multiple environment variables in a single config value**. this is something we do for example when specifying the app domain:
```$_ENV[DW_SUBDOMAIN_APP].$_ENV[DW_HOST]```

2. in the initial migration, i set `charset utf8` to all tables. worked well on a fresh install, but i'm not sure what the overall implications of this are!