### PR TITLE
add indices like in prod

### DIFF
--- a/migrations/011-create-chart-guest-session-index.sql
+++ b/migrations/011-create-chart-guest-session-index.sql
@@ -1,0 +1,7 @@
+-- Create an index for the guest_session field. This is important to quickly match new users former sessions.
+
+-- Up
+CREATE INDEX chart_guest_session_IDX USING BTREE ON chart (guest_session);
+
+-- Down
+DROP INDEX chart_guest_session_IDX ON chart;

--- a/migrations/011-create-chart-guest-session-index.sql
+++ b/migrations/011-create-chart-guest-session-index.sql
@@ -1,7 +1,0 @@
--- Create an index for the guest_session field. This is important to quickly match new users former sessions.
-
--- Up
-CREATE INDEX chart_guest_session_IDX USING BTREE ON chart (guest_session);
-
--- Down
-DROP INDEX chart_guest_session_IDX ON chart;

--- a/migrations/012-add-prod-indices.sql
+++ b/migrations/012-add-prod-indices.sql
@@ -4,10 +4,34 @@
 CREATE INDEX action_key_IDX USING BTREE ON action (key, user_id);
 CREATE INDEX action_action_time_IDX USING BTREE ON action (action_time);
 
+CREATE INDEX chart_idx_is_fork ON chart (is_fork);
+CREATE INDEX chart_author ON chart USING BTREE (author_id);
+CREATE INDEX chart_in_folder_IDX ON chart USING BTREE (in_folder);
+CREATE INDEX chart_organization_id_IDX ON chart USING BTREE (organization_id);
+CREATE INDEX chart_type_IDX ON chart USING BTREE (type);
+CREATE INDEX chart_deleted_IDX ON chart USING BTREE (deleted);
+CREATE INDEX chart_last_modified_at_IDX ON chart USING BTREE (last_modified_at);
+CREATE INDEX chart_forkable_IDX ON chart USING BTREE (forkable);
+CREATE INDEX chart_external_data_IDX ON chart USING BTREE (external_data);
+CREATE INDEX chart_last_edit_step_IDX ON chart USING BTREE (last_edit_step);
+CREATE INDEX chart_guest_session_IDX ON chart USING BTREE (guest_session);
+
 CREATE INDEX chart_guest_session_IDX USING BTREE ON chart (guest_session);
 
 -- Down
 DROP INDEX action_key_IDX ON action;
 DROP INDEX action_action_time_IDX ON action;
+
+DROP INDEX chart_idx_is_fork ON chart;
+DROP INDEX chart_author ON chart;
+DROP INDEX chart_in_folder_IDX ON chart;
+DROP INDEX chart_organization_id_IDX ON chart;
+DROP INDEX chart_type_IDX ON chart;
+DROP INDEX chart_deleted_IDX ON chart;
+DROP INDEX chart_last_modified_at_IDX ON chart;
+DROP INDEX chart_forkable_IDX ON chart;
+DROP INDEX chart_external_data_IDX ON chart;
+DROP INDEX chart_last_edit_step_IDX ON chart;
+DROP INDEX chart_guest_session_IDX ON chart;
 
 DROP INDEX chart_guest_session_IDX ON chart;

--- a/migrations/012-add-prod-indices.sql
+++ b/migrations/012-add-prod-indices.sql
@@ -1,0 +1,13 @@
+-- Create indices that are present in production.
+
+-- Up
+CREATE INDEX action_key_IDX USING BTREE ON action (key, user_id);
+CREATE INDEX action_action_time_IDX USING BTREE ON action (action_time);
+
+CREATE INDEX chart_guest_session_IDX USING BTREE ON chart (guest_session);
+
+-- Down
+DROP INDEX action_key_IDX ON action;
+DROP INDEX action_action_time_IDX ON action;
+
+DROP INDEX chart_guest_session_IDX ON chart;

--- a/migrations/012-add-prod-indices.sql
+++ b/migrations/012-add-prod-indices.sql
@@ -25,6 +25,10 @@ CREATE INDEX last_updated ON session (last_updated);
 CREATE INDEX session_user_id_IDX USING BTREE ON session (user_id);
 CREATE INDEX session_persistent_IDX USING BTREE ON session (persistent);
 
+CREATE INDEX created_at ON user (created_at);
+CREATE INDEX user_email_IDX USING BTREE ON user (email);
+CREATE INDEX user_oauth_signin_IDX USING BTREE ON user (oauth_signin);
+
 -- Down
 DROP INDEX action_key_IDX ON action;
 DROP INDEX action_action_time_IDX ON action;
@@ -49,3 +53,7 @@ DROP INDEX export_job_priority_IDX ON export_job;
 DROP INDEX last_updated ON session;
 DROP INDEX session_user_id_IDX ON session;
 DROP INDEX session_persistent_IDX ON session;
+
+DROP INDEX created_at ON user;
+DROP INDEX user_email_IDX ON user;
+DROP INDEX user_oauth_signin_IDX ON user;

--- a/migrations/012-add-prod-indices.sql
+++ b/migrations/012-add-prod-indices.sql
@@ -18,7 +18,7 @@ CREATE INDEX chart_guest_session_IDX USING BTREE ON chart (guest_session);
 
 CREATE INDEX export_job_created_at_IDX USING BTREE ON export_job (created_at);
 CREATE INDEX export_job_status_IDX USING BTREE ON export_job (status);
-CREATE INDEX export_job_key_IDX USING BTREE ON export_job (key);
+CREATE INDEX export_job_key_IDX USING BTREE ON export_job (`key`);
 CREATE INDEX export_job_priority_IDX USING BTREE ON export_job (priority);
 
 CREATE INDEX last_updated ON session (last_updated);

--- a/migrations/012-add-prod-indices.sql
+++ b/migrations/012-add-prod-indices.sql
@@ -1,10 +1,10 @@
 -- Create indices that are present in production.
 
 -- Up
-CREATE INDEX action_key_IDX USING BTREE ON action (`key`, user_id);
+CREATE INDEX action_key_IDX ON action (`key`, user_id);
 CREATE INDEX action_action_time_IDX USING BTREE ON action (action_time);
 
-CREATE INDEX chart_idx_is_fork USING BTREE ON chart (is_fork);
+CREATE INDEX chart_idx_is_fork ON chart (is_fork);
 CREATE INDEX chart_author USING BTREE ON chart (author_id);
 CREATE INDEX chart_in_folder_IDX USING BTREE ON chart (in_folder);
 CREATE INDEX chart_organization_id_IDX USING BTREE ON chart (organization_id);

--- a/migrations/012-add-prod-indices.sql
+++ b/migrations/012-add-prod-indices.sql
@@ -1,21 +1,19 @@
 -- Create indices that are present in production.
 
 -- Up
-CREATE INDEX action_key_IDX USING BTREE ON action (key, user_id);
+CREATE INDEX action_key_IDX USING BTREE ON action (`key`, user_id);
 CREATE INDEX action_action_time_IDX USING BTREE ON action (action_time);
 
-CREATE INDEX chart_idx_is_fork ON chart (is_fork);
-CREATE INDEX chart_author ON chart USING BTREE (author_id);
-CREATE INDEX chart_in_folder_IDX ON chart USING BTREE (in_folder);
-CREATE INDEX chart_organization_id_IDX ON chart USING BTREE (organization_id);
-CREATE INDEX chart_type_IDX ON chart USING BTREE (type);
-CREATE INDEX chart_deleted_IDX ON chart USING BTREE (deleted);
-CREATE INDEX chart_last_modified_at_IDX ON chart USING BTREE (last_modified_at);
-CREATE INDEX chart_forkable_IDX ON chart USING BTREE (forkable);
-CREATE INDEX chart_external_data_IDX ON chart USING BTREE (external_data);
-CREATE INDEX chart_last_edit_step_IDX ON chart USING BTREE (last_edit_step);
-CREATE INDEX chart_guest_session_IDX ON chart USING BTREE (guest_session);
-
+CREATE INDEX chart_idx_is_fork USING BTREE ON chart (is_fork);
+CREATE INDEX chart_author USING BTREE ON chart (author_id);
+CREATE INDEX chart_in_folder_IDX USING BTREE ON chart (in_folder);
+CREATE INDEX chart_organization_id_IDX USING BTREE ON chart (organization_id);
+CREATE INDEX chart_type_IDX USING BTREE ON chart (type);
+CREATE INDEX chart_deleted_IDX USING BTREE ON chart (deleted);
+CREATE INDEX chart_last_modified_at_IDX USING BTREE ON chart (last_modified_at);
+CREATE INDEX chart_forkable_IDX USING BTREE ON chart (forkable);
+CREATE INDEX chart_external_data_IDX USING BTREE ON chart (external_data);
+CREATE INDEX chart_last_edit_step_IDX USING BTREE ON chart (last_edit_step);
 CREATE INDEX chart_guest_session_IDX USING BTREE ON chart (guest_session);
 
 -- Down
@@ -32,6 +30,4 @@ DROP INDEX chart_last_modified_at_IDX ON chart;
 DROP INDEX chart_forkable_IDX ON chart;
 DROP INDEX chart_external_data_IDX ON chart;
 DROP INDEX chart_last_edit_step_IDX ON chart;
-DROP INDEX chart_guest_session_IDX ON chart;
-
 DROP INDEX chart_guest_session_IDX ON chart;

--- a/migrations/012-add-prod-indices.sql
+++ b/migrations/012-add-prod-indices.sql
@@ -16,6 +16,11 @@ CREATE INDEX chart_external_data_IDX USING BTREE ON chart (external_data);
 CREATE INDEX chart_last_edit_step_IDX USING BTREE ON chart (last_edit_step);
 CREATE INDEX chart_guest_session_IDX USING BTREE ON chart (guest_session);
 
+CREATE INDEX export_job_created_at_IDX USING BTREE ON export_job (created_at);
+CREATE INDEX export_job_status_IDX USING BTREE ON export_job (status);
+CREATE INDEX export_job_key_IDX USING BTREE ON export_job (key);
+CREATE INDEX export_job_priority_IDX USING BTREE ON export_job (priority);
+
 -- Down
 DROP INDEX action_key_IDX ON action;
 DROP INDEX action_action_time_IDX ON action;
@@ -31,3 +36,8 @@ DROP INDEX chart_forkable_IDX ON chart;
 DROP INDEX chart_external_data_IDX ON chart;
 DROP INDEX chart_last_edit_step_IDX ON chart;
 DROP INDEX chart_guest_session_IDX ON chart;
+
+DROP INDEX export_job_created_at_IDX ON export_job;
+DROP INDEX export_job_status_IDX ON export_job;
+DROP INDEX export_job_key_IDX ON export_job;
+DROP INDEX export_job_priority_IDX ON export_job;

--- a/migrations/012-add-prod-indices.sql
+++ b/migrations/012-add-prod-indices.sql
@@ -21,6 +21,10 @@ CREATE INDEX export_job_status_IDX USING BTREE ON export_job (status);
 CREATE INDEX export_job_key_IDX USING BTREE ON export_job (key);
 CREATE INDEX export_job_priority_IDX USING BTREE ON export_job (priority);
 
+CREATE INDEX last_updated ON session (last_updated);
+CREATE INDEX session_user_id_IDX USING BTREE ON session (user_id);
+CREATE INDEX session_persistent_IDX USING BTREE ON session (persistent);
+
 -- Down
 DROP INDEX action_key_IDX ON action;
 DROP INDEX action_action_time_IDX ON action;
@@ -41,3 +45,7 @@ DROP INDEX export_job_created_at_IDX ON export_job;
 DROP INDEX export_job_status_IDX ON export_job;
 DROP INDEX export_job_key_IDX ON export_job;
 DROP INDEX export_job_priority_IDX ON export_job;
+
+DROP INDEX last_updated ON session;
+DROP INDEX session_user_id_IDX ON session;
+DROP INDEX session_persistent_IDX ON session;


### PR DESCRIPTION
After this migration a dev instance will have the same indices like the production DB. This might help getting an overview which columns need to receive an extra index before pushing some complicated query to prod. 