### PR TITLE
Don't toggle if Svelte group

### DIFF
--- a/www/static/js/dw/chart/visualize/options.js
+++ b/www/static/js/dw/chart/visualize/options.js
@@ -43,7 +43,9 @@ function(initCustomColors, syncVisOptions, unsyncVisOptions) {
                 $('#vis-options-'+key)[val == 'open' ? 'addClass' : 'removeClass']('group-open');
             });
 
-            $('.vis-option-type-group:not(.notoggle) > label.group-title').click(function() {
+            // don't react to a group that contains `svelte-group` class,
+            // since it will handle the toggle functionality on its own
+            $('.vis-option-type-group:not(.notoggle,.svelte-group) > label.group-title').click(function() {
                 var $g = $(this).parents('.vis-option-type-group').toggleClass('group-open');
                 $(window).resize();
                 try {


### PR DESCRIPTION
There is a small bug when using Svelte controls in the annotate tab in chart editor: toggling a collapsible group currently makes controls inside of it invisible.

![toggle-group](https://user-images.githubusercontent.com/6787862/82351140-7d3a4300-99fc-11ea-81b6-5f285bf0a514.gif)

This happens because the toggle event gets simultaneously handled by Svelte controls and in [`options.js`](https://github.com/datawrapper/datawrapper/blob/master/www/static/js/dw/chart/visualize/options.js).

The solution is to check if a group being clicked on comes from Svelte controls and has the `svelte-group` class, in which case we ignore the click in `options.js` and let Svelte controls handle the toggling.

[Corresponding PR in @datawrapper/controls which adds the required class](https://github.com/datawrapper/controls/pull/69).