### PR TITLE
Only include needed metadata

### DIFF
--- a/controller/mycharts.php
+++ b/controller/mycharts.php
@@ -186,7 +186,18 @@ function prepare_short_arrays($charts) {
 
     foreach ($charts as $chart) {
         $flat = $chart->serialize(true);
-        unset($flat['metadata']['publish']['embed-codes']);
+
+        $flat['metadata'] = [
+            'visualize' => [
+                'map-type-set' => $flat['metadata']['visualize']['map-type-set'] ?? false
+            ],
+            'publish' => [
+                'embed-height' => $flat['metadata']['publish']['embed-height'] ?? false,
+                'embed-width' => $flat['metadata']['publish']['embed-width'] ?? false,
+                'background' => $flat['metadata']['publish']['background'] ?? false
+            ]
+        ];
+
         $flat['hash'] = $dw_config["screenshot_path"] ?? $chart->getHash();
         $shorty[$flat['id']] = $flat;
     }

--- a/sha
+++ b/sha
@@ -1,1 +1,1 @@
-3b7ff23a27e6c332aeea01ebafbb2edffea17316
+a94ea7cc0a63ff38ca048a6cb38753498ca024fd


### PR DESCRIPTION
Instead of piping a ton of serialized charts to the frontend, only send the needed metadata (speeds up mycharts and fixes some bugs)