### PR TITLE
Remove < and > from embed codes in php, bring them back when user copies code

### DIFF
--- a/controller/mycharts.php
+++ b/controller/mycharts.php
@@ -187,6 +187,13 @@ function prepare_short_arrays($charts) {
     foreach ($charts as $chart) {
         $flat = $chart->serialize(true);
 
+        if (isset($flat['metadata']['publish']['embed-codes'])) {
+            $embed_codes = [];
+            foreach ($flat['metadata']['publish']['embed-codes'] as $key => $value) {
+                $embed_codes[$key] = str_replace('<','&#60;',$value);
+                $embed_codes[$key] = str_replace('>','&#62;',$embed_codes[$key]);
+            }
+        }
         $flat['metadata'] = [
             'visualize' => [
                 'map-type-set' => $flat['metadata']['visualize']['map-type-set'] ?? false
@@ -195,7 +202,7 @@ function prepare_short_arrays($charts) {
                 'embed-height' => $flat['metadata']['publish']['embed-height'] ?? false,
                 'embed-width' => $flat['metadata']['publish']['embed-width'] ?? false,
                 'background' => $flat['metadata']['publish']['background'] ?? false,
-                'embed-codes' => $flat['metadata']['publish']['embed-codes'] ?? false
+                'embed-codes' => $embed_codes ?? false
             ]
         ];
 

--- a/www/static/js/dw/mycharts/showChartModal.js
+++ b/www/static/js/dw/mycharts/showChartModal.js
@@ -79,7 +79,7 @@ define(function() {
             $('ul.embed-codes li a', wrapper).click(function(evt) {
                 clearTimeout(timeout);
                 var key = $(this).data('embed-method');
-                var textarea = $('.embed-code-copy', wrapper).val(chart.metadata.publish['embed-codes'][key]);
+                var textarea = $('.embed-code-copy', wrapper).val(chart.metadata.publish['embed-codes'][key].replace(/&#60;/gm,'<').replace(/&#62;/gm,'>'));
                 textarea.get(0).select();
                 var ok = document.execCommand('copy');
                 if (ok) {


### PR DESCRIPTION
Unclosed `<` tags in embed codes break mycharts, this should fix that. But there may be a preferable way to do so..?