### PR TITLE
Use _.isEqual

### DIFF
--- a/www/static/js/dw/chart/visualize/liveUpdate.js
+++ b/www/static/js/dw/chart/visualize/liveUpdate.js
@@ -74,7 +74,8 @@ define(function () {
                         p0 = p0[k] || {};
                         p1 = p1[k] || {};
                     });
-                    return JSON.stringify(p0) !== JSON.stringify(p1);
+
+                    return !_.isEqual(p0, p1);
                 }
             },
             saved: function () {


### PR DESCRIPTION
Using `_.isEqual` instead of comparing `JSON.stringify` fixes a bug that caused visualizations to be re-rendered needlessly when the _order of keys_ in an object changed.

Underscore is currently still a globally [available dependency from core.twig](https://github.com/datawrapper/datawrapper/blob/is-equal/templates/core.twig#L54), so should be fine to use here.