### PR TITLE
without this options curl waits (forever) for body when method is HEAD

### DIFF
--- a/lib/utils/call_v3_api.php
+++ b/lib/utils/call_v3_api.php
@@ -61,6 +61,7 @@ function call_v3_api($method, $route, $payload = null, $contentType = 'applicati
     curl_setopt_array($ch, [
         CURLOPT_URL => "$protocol://$apiDomain/v3$route",
         CURLOPT_CUSTOMREQUEST => $method,
+        CURLOPT_NOBODY => $method === 'HEAD',
         CURLOPT_RETURNTRANSFER => 1,
         CURLOPT_HTTPHEADER => $headers,
         CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS


### PR DESCRIPTION
The docs of `CURLOPT_CUSTOMREQUEST` explicitly say methods custom _other_ than `GET`& `HEAD` but it seems to work anyways.
A few lines below that they state that `GET` is an allowed value, so this is kinda misleading.

Nevertheless curl _needs_ the `CURLOPT_NOBODY` option set for `HEAD` requests because it parses the body size which is transferred on `HEAD` too and it will wait for bytes to come without it.